### PR TITLE
Nil item link

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -4,7 +4,6 @@ move-folders:
   ItemVersion/ItemVersion: ItemVersion
 
 ignore:
-  - README.md
   - CHANGELOG.md
   - release.sh
   - bumpver.toml

--- a/ItemVersion/Tooltip.lua
+++ b/ItemVersion/Tooltip.lua
@@ -13,6 +13,13 @@ end
 
 local function OnTooltipSetItem(tooltip)
   local _, link = tooltip:GetItem()
+
+  -- happens when looking at crafting spells at profession trainer, despite this function
+  -- only being called on item tooltips: blizzard strangeness.
+  if not link then
+    return
+  end
+
   local itemId = tonumber(strmatch(link, ':(%w+)'))
   local left, right = tooltipString(itemId)
   tooltip:AddDoubleLine(left, right);

--- a/README.md
+++ b/README.md
@@ -53,3 +53,10 @@ This is the format: `year.weeknumber.patch`.
 
 Data refresh releases will bump the `year.weeknumber` part. Intraweek development releases will bump
 the `patch` part.
+
+## License
+
+Copyright 2020 Tim Martin
+
+Licensed under the GPLv3:
+[https://www.gnu.org/licenses/gpl-3.0.en.html](https://www.gnu.org/licenses/gpl-3.0.en.html)


### PR DESCRIPTION
Fixes #2.

When viewing profession trainers' crafting spells, no item link is returned from the `tooltip:GetItem()`. While it is strange that Blizzard uses the _item_ tooltip to show these spells, it doesn't really make sense to show item information on a spell anyway.

Fixed by checking for `nil` return value from the above function.