### PR TITLE
Use two-branch git workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,11 @@
 name: Build
 
-# This workflow creates a usable addon zip for each commit. One reason for this is that it lets
-# contributors get a build without having to install wap (begrudingly).
+# This workflow creates a usable addon zip for each commit.
+#
+# One reason for this is that it lets contributors get a build without having to install wap
+# (begrudingly). To download it, head to this check's run page and click on "Summary" in the
+# left-hand column. There, towards the bottom of the page, there will be an "Artifacts" section
+# where the built addon zip file can be found.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,11 +6,12 @@ on:
     branches:
       - master
 
-
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    env:
+      NEW_DIR: build-from-commit-artifact
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -21,18 +22,19 @@ jobs:
         release-type: 'none'
 
     - name: Surface addons
-      # upload-artifact sets the root directory of the artifact zip to the path segment that has the first wildcard.
-      # our dist dir is in the format dist/ItemVersion-X.Y.Z/ItemVersion/foo.lua. Because
-      # we don't know X.Y.Z (and don't want to calculate it), we'd need a wildcard at
-      # that point (dist/ItemVersion*/*). But, then the ItemVersion-X.Y.Z dir would be at the root.
-      # We want just the addon folders at the root instead (matches normal addon zip structure). So, we move those
-      # addon folders up (or "surface" them) in new dir, and then pass dir that to upload-artifact
+      # upload-artifact sets the root directory of the artifact zip to the path segment that has the
+      # first wildcard. our dist dir is in the format dist/ItemVersion-X.Y.Z/ItemVersion/foo.lua.
+      # Because we don't know X.Y.Z (and don't want to calculate it), we'd need a wildcard at that
+      # point (dist/ItemVersion*/*). But, then the ItemVersion-X.Y.Z dir would be at the root. We
+      # want just the addon folders at the root instead (matches normal addon zip structure). So, we
+      # move those addon folders up (or "surface" them) in new dir, and then pass dir that to
+      # upload-artifact
       shell: bash
       run: |
-        mkdir build-from-commit-artifact
-        mv dist/ItemVersion*/* build-from-commit-artifact
+        mkdir ${NEW_DIR}
+        mv dist/ItemVersion*/* ${NEW_DIR}
 
     - uses: actions/upload-artifact@v3
       with:
         name: ItemVersion-${{ github.sha }}
-        path: build-from-commit-artifact/*
+        path: ${{ env.NEW_DIR }}/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,8 @@
 name: Build
+
+# This workflow creates a usable addon zip for each commit. One reason for this is that it lets
+# contributors get a build without having to install wap (begrudingly).
+
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -1,0 +1,54 @@
+name: Merge Master
+
+# 1. Merge master into release branch
+# 2. Push release branch
+# 3. Run release workflow (see release.yml)
+#
+# This workflow is done manually (workflow_dispatch) when the work on master is in a releaseable
+# state
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        description: "The type of wap release to perform (or none at all)"
+        type: choice
+        options:
+          - "none"
+          - "alpha"
+          - "beta"
+          - "release"
+        required: true
+
+jobs:
+  merge:
+    name: Merge Master into Release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout addon code
+      uses: actions/checkout@v3
+      with:
+        ref: release
+        token: ${{ secrets.GH_PAT }}
+        fetch-depth: 0  # needed to know about origin/master
+
+    - name: Git Config
+      shell: bash
+      run: |
+        git config user.name "${GITHUB_ACTOR}"
+        git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+    - name: Put master on release
+      run: |
+        git merge origin/master
+
+    - name: Git Push
+      run: |
+        git push origin release
+
+  release:
+    needs: merge
+    uses: ./.github/workflows/release.yml
+    with:
+      release-type: ${{ inputs.release-type }}
+    secrets: inherit

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,4 +1,7 @@
 name: PR Checks
+
+# Run checks that ensure code quality of pull requests
+
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -1,19 +1,30 @@
 name: Refresh Data
 
-# jobs
-# 1. run scrape from item-version-scrape
-#   - output to dist/Data.lua and upload artifact
-#   - if cache has been updated, make a commit and push to that repo
-# 2. incorporate new Data.lua
-#   - download artifact
-#   - make commit and push
-# 3. run release workflow
+# 1. Run scrape from item-version-scrape
+#   - Output to dist/Data.lua and upload artifact
+#   - If cache has been updated, make a commit and push it back to save progress
+# 2. On release branch, download new Data.lua artifact, and commit and push it. (This is
+#    intentionally not done on master branch -- master branch has a different lifecycle than the
+#    weekly data refreshes. master branch is where we do development, and we don't want master's
+#    possibly-unfinished things to be auto-merged into release branch every week.)
+# 3. Run release workflow (see release.yml)
+#
+# This workflow is done automatically on Tuesdays at 16:00 UTC (1 hour after wow weekly reset), or
+# by manual workflow_dispatch.
 
 on:
   workflow_dispatch:
+    inputs:
+      release-type:
+        description: "The type of wap release to perform (or none at all)"
+        type: choice
+        options:
+          - "none"
+          - "alpha"
+          - "beta"
+          - "release"
+        required: true
   schedule:
-    # run on tuesdays at 16:00 UTC (1 hour after wow weekly reset)
-    # runs on the last commit on the default branch
     - cron: "0 16 * * 2"
 
 jobs:
@@ -21,83 +32,90 @@ jobs:
     name: Scrape
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          ref: master
-          repository: t-mart/item-version-scrape
-          token: ${{ secrets.GH_PAT }}
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        ref: master
+        repository: t-mart/item-version-scrape
+        token: ${{ secrets.GH_PAT }}
 
-      - name: Install Poetry
-        run: |
-          pipx install poetry
+    - name: Install Poetry
+      run: |
+        pipx install poetry
 
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-          cache: "poetry"
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+        cache: "poetry"
 
-      - name: Install dependencies
-        run: |
-          poetry install
+    - name: Install dependencies
+      run: |
+        poetry install
 
-      - name: Scrape
-        run: |
-          poetry run ivs scrape
+    - name: Scrape
+      run: |
+        poetry run ivs scrape
 
-      - uses: actions/upload-artifact@v3
-        with:
-          name: Data.lua
-          path: dist/Data.lua
+    - uses: actions/upload-artifact@v3
+      with:
+        name: Data.lua
+        path: dist/Data.lua
 
-      - name: Check if cache updated
-        id: cache-updated
-        run: |
-          RESULT=$(git diff --exit-code --quiet ./cache && echo "0" || echo "1")
-          echo "CACHE_UPDATED=$RESULT" >> $GITHUB_OUTPUT
+    - name: Check if cache updated
+      id: cache-updated
+      run: |
+        RESULT=$(git diff --exit-code --quiet ./cache && echo "0" || echo "1")
+        echo "CACHE_UPDATED=${RESULT}" >> ${GITHUB_OUTPUT}
 
-      - name: Commit
-        if: steps.cache-updated.outputs.CACHE_UPDATED == '1'
-        run: |
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git add ./cache
-          git commit -m "Update cache"
-          git push origin "${{ github.ref_name }}"
+    - name: Commit
+      if: steps.cache-updated.outputs.CACHE_UPDATED == '1'
+      run: |
+        git config user.name "${GITHUB_ACTOR}"
+        git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+        git add ./cache
+        git commit -m "Update cache"
+        git push origin "${{ github.ref_name }}"
 
   commit:
     name: Commit new item data
     runs-on: ubuntu-latest
     needs: scrape
     steps:
-      - name: Checkout addon code
-        uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.GH_PAT }}
+    - name: Checkout addon code
+      uses: actions/checkout@v3
+      with:
+        ref: release
+        token: ${{ secrets.GH_PAT }}
 
-      - name: Clear old data
-        run: |
-          rm ItemVersion/Data.lua
+    - name: Clear old data
+      run: |
+        rm ItemVersion/Data.lua
 
-      - name: Download generated lua artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: Data.lua
-          path: ItemVersion/
+    - name: Download generated lua artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: Data.lua
+        path: ItemVersion/
 
-      - name: Commit and push
-        run: |
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git add ItemVersion/Data.lua
-          git commit -m "Refresh item data"
-          git push origin master
+    - name: Git Config
+      shell: bash
+      run: |
+        git config user.name "${GITHUB_ACTOR}"
+        git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+    - name: Commit & Push
+      run: |
+        git add ItemVersion/Data.lua
+        git commit -m "Refresh item data"
+
+    - name: Git Push
+      run: |
+        git push origin release
 
   release:
     needs: commit
     uses: ./.github/workflows/release.yml
     with:
-      git-ref: master
-      release-type: release
+      release-type: ${{ inputs.release-type || 'release' }}  # release if no input specified (cron)
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,31 +1,24 @@
 name: Release
 
+# On release branch:
+# 1. Add a version bump commit
+# 2. Tag it
+# 3. wap build/publish the addon
+# 4. Make a GH release (with the addon file)
+# 5. Merge it back to master branch (so that the two branches stay in sync)
+#
+# This workflow doesn't run on its own -- its called by other workflows that have put something
+# releaseable on release branch (refresh-data.yml or merge-master.yml)
+
 on:
-  workflow_dispatch:
-    inputs:
-      release-type:
-        description: "The type of wap release to perform (or none at all)"
-        type: choice
-        options:
-          - "none"
-          - "alpha"
-          - "beta"
-          - "release"
-        required: false
-        default: "beta"
   workflow_call:
     inputs:
-      git-ref:
-        type: string
-        required: false
-        default: ''
       release-type:
         type: string
-        required: false
-        default: "beta"
+        required: true
     secrets:
-      CF_API_KEY:
-        required: false
+      GH_PAT:
+        required: true
 
 jobs:
   release:
@@ -35,8 +28,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        ref: ${{ inputs.git-ref }}
+        ref: release
         token: ${{ secrets.GH_PAT }}
+        fetch-depth: 0  # ensure git knows about shared history between release and master
 
     - name: Setup Node 18
       uses: actions/setup-node@v3
@@ -53,28 +47,38 @@ jobs:
       shell: bash
       run: |
         LAST_VERSION=$(jq <"wap.json" ".version" --raw-output)
-        echo "Last version was $LAST_VERSION"
-        NEXT_VERSION=$(calver inc --format yyyy.0w.patch --levels calendar.patch $LAST_VERSION)
-        echo "Next version is $NEXT_VERSION"
-        echo "version=$NEXT_VERSION" >> $GITHUB_OUTPUT
+        echo "Last version was ${LAST_VERSION}"
+        NEXT_VERSION=$(calver inc --format yyyy.0w.patch --levels calendar.patch ${LAST_VERSION})
+        echo "Next version is ${NEXT_VERSION}"
+        echo "version=${NEXT_VERSION}" >> ${GITHUB_OUTPUT}
 
     - name: Update wap.json version
       shell: bash
       run: |
-        jq  ".version = \"$NEXT_VERSION\"" <wap.json >wap-next.json
+        jq  ".version = \"${NEXT_VERSION}\"" <wap.json >wap-next.json
         mv wap-next.json wap.json
       env:
         NEXT_VERSION: "${{ steps.next-version.outputs.version }}"
 
-    - name: Commit, tag, and push
+    - name: Git Config
       shell: bash
       run: |
         git config user.name "${GITHUB_ACTOR}"
         git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+    - name: Git Commit & Tag
+      shell: bash
+      run: |
         git add wap.json
-        git commit -m "Release $NEXT_VERSION"
-        git tag -a "$NEXT_VERSION" -m "Release $NEXT_VERSION"
-        git push --atomic origin "${{ github.ref_name }}" "$NEXT_VERSION"
+        git commit -m "Release ${NEXT_VERSION}"
+        git tag -a "${NEXT_VERSION}" -m "Release ${NEXT_VERSION}"
+      env:
+        NEXT_VERSION: "${{ steps.next-version.outputs.version }}"
+
+    - name: Git Push
+      shell: bash
+      run: |
+        git push --atomic origin release "${NEXT_VERSION}"
       env:
         NEXT_VERSION: "${{ steps.next-version.outputs.version }}"
 
@@ -86,7 +90,13 @@ jobs:
 
     - name: GH Release
       run: |
-        gh release create --generate-notes "$NEXT_VERSION" dist/*.zip
+        gh release create --generate-notes "${NEXT_VERSION}" dist/*.zip
       env:
         NEXT_VERSION: "${{ steps.next-version.outputs.version }}"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Merge back into master
+      run: |
+        git checkout master
+        git merge release
+        git push origin master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,9 +16,9 @@
 ## Developer Environment
 
 ItemVersion uses [`wap`](https://t-mart.github.io/wap/) for most development tasks. See [wap for
-Contributors](https://t-mart.github.io/wap/contributors/) to get started. Using `wap` will give you
-a nice developer experience that automatically rebuilds on file changes and links ItemVersion into
-your `Interface/AddOns` directory.
+Collaborators](https://t-mart.github.io/wap/wap-for-collaborators/) to get started. Using `wap` will
+give you a nice developer experience that automatically rebuilds on file changes and links
+ItemVersion into your `Interface/AddOns` directory.
 
 In particular, if you do not use `wap` to build the addon, you won't be able to use it in the game.
 This is because `wap` transforms the source files here into a usable addon.


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Item fix
- [ ] Documentation
- [x] Other

## Checklist

- [x] I've tested what I've added
- [ ] I've updated AUTHORS.md with my name (if I want to)

## Description

This project is released in two scenarios:
- Automatically for the weekly data refresh, where we get the latest items
- Manually, when development has new stuff to deliver to users

Both of these things take (took) place on `master` branch. But, this was problematic because these two scenarios differ in lifecycle. One runs automatically, the other, manually. Specifically, development work on `master` would get whisked away: conflated into the weekly data refresh, no matter if it was really intended to be released.

One solution to this is this to have a separate `release` branch. That way, the weekly data refresh can be applied to it, and not to `master`. Then, master can work on what it needs to without worry of any timelines. And that's what this PR seeks to do with a whole new set of workflow files. See the comments at the top of each one for details.
