### PR TITLE
Hook Item Ref tooltip too in non-mainline

### DIFF
--- a/ItemVersion/Tooltip.lua
+++ b/ItemVersion/Tooltip.lua
@@ -83,6 +83,8 @@ end
 
 function TooltipMixin:GetOnTooltipSetItemFn()
   return function(tooltip, data)
+    -- GameTooltip is the one attached to the mouse
+    -- ItemRefTooltip is the static one after clicking an item link
     if (tooltip ~= GameTooltip and tooltip ~= ItemRefTooltip) then
       return
     end
@@ -97,7 +99,7 @@ function TooltipMixin:GetOnTooltipSetItemFn()
       itemId = data.id
     else
       -- classic way
-      local name, link = GameTooltip:GetItem() -- will this break if its ItemRefTooltip?
+      local name, link = tooltip:GetItem()
       if (link) and (name) then
         itemId = tonumber(string.match(link, "item:(%d*)"))
       end
@@ -125,5 +127,6 @@ function TooltipMixin:HookTooltipCall()
     TooltipDataProcessor.AddTooltipPostCall(Enum.TooltipDataType.Item, self:GetOnTooltipSetItemFn())
   else
     GameTooltip:HookScript("OnTooltipSetItem", self:GetOnTooltipSetItemFn())
+    ItemRefTooltip:HookScript("OnTooltipSetItem", self:GetOnTooltipSetItemFn())
   end
 end


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Item fix
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I've tested what I've added
- [ ] I've updated AUTHORS.md with my name (if I want to)

## Description

In classic, you need to hook both `GameTooltip` and `ItemRefTooltip`.
